### PR TITLE
Take focused window to new context, Remember renamed workspaces

### DIFF
--- a/XMonad/Actions/Contexts.hs
+++ b/XMonad/Actions/Contexts.hs
@@ -118,7 +118,10 @@ mergeContexts ids ctxOld ctxNew = do
         W.current = newFocused
     }
 
-    Context mergedStack (workspaceNames ctxNew)
+    -- copy workspace names
+    let mergedWsNames = zipWith selectWsName (workspaceNames ctxOld) (workspaceNames ctxNew)
+
+    Context mergedStack mergedWsNames
 
         where
             selectScreen screen = do
@@ -129,8 +132,11 @@ mergeContexts ids ctxOld ctxNew = do
 
             workspacesOld = W.workspaces (windowSet ctxOld)
 
-            {- oldWs :: W.Workspace i l a -> W.Workspace i l a -}
             oldWs ws = fromMaybe ws (find (\x -> W.tag ws == W.tag x) workspacesOld) -- if tag is not found in workspacesOld, return new ws
+
+            
+            selectWsName (tag, nameOld) (_, nameNew) = if tag `elem` ids then (tag, nameOld) else (tag, nameNew)
+
 
 -- set the window set and apply the workspaceNames
 setWindowsAndWorkspaces :: [WorkspaceId] -> Context -> Context -> X ()


### PR DESCRIPTION
Hey, I would like to revive this project and have started with two features.

First, I have implemented a minimal solution for #2. This can probably be extended to be more useful. Currently, it only supports taking a window with you when switching contexts. It does not support just sending a window to another context.
Also, I noticed a bug, which probably only occuers in combination with [Smart Borders](https://hackage.haskell.org/package/xmonad-contrib-0.17.1/docs/XMonad-Layout-NoBorders.html#v:smartBorders).
When taking a full screen window (so no borders) from context A to context B and the window is not full screen in context B, the borders are missing. A workaround is to switch to another context and then back.
I have tried [`refresh`](https://hackage.haskell.org/package/xmonad-0.17.1/docs/XMonad-Operations.html#v:refresh) and [`rescreen`](https://hackage.haskell.org/package/xmonad-0.17.1/docs/XMonad-Operations.html#v:rescreen) but they don't solve this. I am not too deep into XMonad to tell how to solve this

Secondly, I am using [NamedWindows](https://hackage.haskell.org/package/xmonad-contrib-0.17.1/docs/XMonad-Util-NamedWindows.html), so I have implemented that the named workspaces are stored per context.
This should not influence the behavior when not using NamedWIndows, but this is untested.

I am happy to explain any part of the code, or change or remove parts from this PR.

PS: While trying to understand how this plugin works, I have renamed some variables. I think they are a bit easier to understand now, but if you want, I can change them back.